### PR TITLE
Fix for Confusing method names because of capitalization

### DIFF
--- a/src/test/kotlin/no/nav/tilgangsmaskin/ansatt/oppfølging/OppfølgingTjenesteTest.kt
+++ b/src/test/kotlin/no/nav/tilgangsmaskin/ansatt/oppfølging/OppfølgingTjenesteTest.kt
@@ -100,7 +100,7 @@ class OppfølgingTjenesteTest : BehaviorSpec() {
             When("avslutt kalles etter registrering") {
                 Then("fjernes cache-innslag for brukerId og aktørId") {
                     val id = randomUUID()
-                    tjeneste.registrer(id, IDENTER, KONTOR)
+                    tjeneste.registrer(id, IDENTER, kontorHendelse)
                     cache.getOne<Enhetsnummer>(OPPFØLGING_CACHE, brukerId.verdi) shouldBe kontor
                     cache.getOne<Enhetsnummer>(OPPFØLGING_CACHE, aktørId.verdi) shouldBe kontor
 
@@ -118,7 +118,7 @@ class OppfølgingTjenesteTest : BehaviorSpec() {
         private val aktørId  = AktørId("1234567890123")
         private val kontor   = Enhetsnummer("1234")
         private val IDENTER  = Identer(brukerId, aktørId)
-        private val KONTOR = Kontor(kontor, "Testenhet")
+        private val kontorHendelse = Kontor(kontor, "Testenhet")
         @ServiceConnection
         private val postgres = PostgreSQLContainer("postgres:17")
     }


### PR DESCRIPTION
The best fix is to rename one of the two companion-object properties so their generated getter names are not distinguished only by letter case. Since `kontor` is a simple underlying value (`Enhetsnummer`) and `KONTOR` is the domain event payload (`Kontor`), the clearest non-breaking test intent is to rename `KONTOR` to a descriptive mixed/lower camel-case name such as `kontorHendelse`, and update its use at the call site.

In `src/test/kotlin/no/nav/tilgangsmaskin/ansatt/oppfølging/OppfølgingTjenesteTest.kt`:
- In the companion object, change `private val KONTOR = Kontor(kontor, "Testenhet")` to `private val kontorHendelse = Kontor(kontor, "Testenhet")`.
- In the test body where `tjeneste.registrer(id, IDENTER, KONTOR)` is called, replace `KONTOR` with `kontorHendelse`.

No imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._